### PR TITLE
Json schema, partial PR

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "respect/validation": "^1.1",
         "slim/csrf": "^0.7.0",
         "slim/flash": "^0.1.0",
-        "joshcam/mysqli-database-class": "^2.6"
+        "joshcam/mysqli-database-class": "^2.6",
+        "geraintluff/jsv4": "dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "78ed6ba7ba78b67be1b63de930ff8066",
-    "content-hash": "ca2a6f0f0cf3e6bfde50a48a9529b1da",
+    "hash": "3bf2c9ea44e6b4ca2d8d520def79ae0e",
+    "content-hash": "b931cfef58591133bf8ae29be43166e5",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -33,6 +33,56 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "time": "2014-12-30 15:22:37"
+        },
+        {
+            "name": "geraintluff/jsv4",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/geraintluff/jsv4-php.git",
+                "reference": "b0fd384506e3b5c109777e6260523d4f76517537"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/geraintluff/jsv4-php/zipball/b0fd384506e3b5c109777e6260523d4f76517537",
+                "reference": "b0fd384506e3b5c109777e6260523d4f76517537",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Jsv4": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Martin Bažík",
+                    "email": "martin@bazo.sk",
+                    "homepage": "http://bazo.sk"
+                },
+                {
+                    "name": "Geraint Luff",
+                    "email": "luffgd@gmail.com"
+                }
+            ],
+            "description": "A (coercive) JSON Schema v4 Validator for PHP",
+            "keywords": [
+                "Geraint Luff",
+                "JSON Schema",
+                "geraintluff",
+                "json",
+                "schema",
+                "v4",
+                "validator"
+            ],
+            "time": "2015-10-08 15:40:29"
         },
         {
             "name": "joshcam/mysqli-database-class",
@@ -795,7 +845,9 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "geraintluff/jsv4": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/glued/Controllers/Api/README
+++ b/glued/Controllers/Api/README
@@ -1,0 +1,22 @@
+JSON SCHEMA
+
+* Implementations: http://json-schema.org/implementations
+* Generate schemas from example data: http://www.jsonschema.net/
+* Validator in use: https://github.com/geraintluff/jsv4-php
+* Online validator: http://jsonschemalint.com/#/version/draft-04/markup/json
+
+DONE
+
+* Selected jsv4-php as the backend validator
+* Enveloped all api paths into a group that has access the jsv4 class.
+* Written the first test schema (see Controllers/Api/v0_1/schemas/timepixels.json)
+* Tested validity of GET glued/public/api/0.1/timepixels/1 against the timepixels.json schema with the Online validator.
+
+TODO
+
+* TODO consider moving jsv4 class loading into an (as of yet nonexistent) API base controller
+* Break up timepixels.json schema into components, test embedding/referencing with jsv4-php. Also see 
+  * https://code.tutsplus.com/tutorials/validating-data-with-json-schema-part-2--cms-25640
+  * https://spacetelescope.github.io/understanding-json-schema/structuring.html
+* Choose/test form generation frontend library to generate sample forms (also capable of schema referencing) and aid with setting the correct combination of "required" rules
+  * https://github.com/icebob/vue-form-generator

--- a/glued/Controllers/Api/v0_1/schemas/timepixels.json
+++ b/glued/Controllers/Api/v0_1/schemas/timepixels.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "dt_end": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "announce": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string"
+            },
+            "oauth2": {
+              "type": "string"
+            }
+          },
+          "required": ["url"]
+        },
+        "dt_start": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "object",
+          "properties": {
+            "counted": {
+              "type": "string"
+            },
+            "expected": {
+              "type": "string"
+            }
+          },
+          "anyOf": [{
+            "required": ["counted"]
+          }, {
+            "required": ["expected"]
+          }]
+        },
+        "timezone": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "anyOf": [{
+              "required": ["name"]
+            }, {
+              "required": ["id", "name"]
+            }]
+          }
+        }
+      },
+      "required": [
+        "title",
+        "dt_start"
+      ]
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/glued/bootstrap.php
+++ b/glued/bootstrap.php
@@ -2,7 +2,7 @@
 
 // Respect pulled in here because of v::with() below
 use Respect\Validation\Validator as v;
-
+//use Jsv4\Validator as jsonv;
 
 session_start();
 
@@ -12,11 +12,8 @@ require __DIR__ . '/../vendor/autoload.php';
 
 // Instantiate the app, setup the path to our custom validation rules
 $config = require __DIR__ . '/settings.php';
-$app = new \Slim\App($config); // -this: we're not using plain slim anymore, but extend it with App.php
-//$app = new \Glued\App($config);   // +this
-
+$app = new \Slim\App($config);
 v::with('Glued\\Classes\\Validation\\Rules\\');
-
 
 // Set up dependencies
 require __DIR__ . '/dependencies.php';

--- a/glued/routes.php
+++ b/glued/routes.php
@@ -49,8 +49,29 @@ $app->group('', function () {
 
 // APIs
 
+$app->group('', function () {
+  use Jsv4\Validator as jsonv;
+  $this->get('/api/0.1/test[/{id}]', '\Glued\Controllers\Api\v0_1\TestController::get');
+  $this->get('/jsonvtest', function ($request, $response) {
+    return jsonv::isValid([ 'a' => 'b' ], []);
+  });
+
+  // timepixels
+  $this->get('/api/0.1/timepixels[/{id}]', 'TimeController:get');
+  $this->put('/api/0.1/timepixels[/{id}]', '\Glued\Controllers\Api\v0_1\TimePixelsController::put');
+  $this->post('/api/0.1/timepixels[/]', 'TimeController:post');
+  //$app->delete('/api/0.1/timepixels[/{id}]', '\Glued\Controllers\Api\v0_1\TimePixelsController::delete');
+  $app->delete('/api/0.1/timepixels[/{id}]', 'TimeController:delete');
+});
+
+/*
 // test
 $app->get('/api/0.1/test[/{id}]', '\Glued\Controllers\Api\v0_1\TestController::get');
+$app->get('/jsonvtest', function ($request, $response) {
+  use Jsv4\Validator as jsonv;
+  return jsonv::isValid([ 'a' => 'b' ], []);
+});
+
 
 // timepixels
 $app->get('/api/0.1/timepixels[/{id}]', 'TimeController:get');
@@ -59,7 +80,7 @@ $app->post('/api/0.1/timepixels[/]', 'TimeController:post');
 
 //$app->delete('/api/0.1/timepixels[/{id}]', '\Glued\Controllers\Api\v0_1\TimePixelsController::delete');
 $app->delete('/api/0.1/timepixels[/{id}]', 'TimeController:delete');
-
+*/
 
 
 /**

--- a/vendor/composer/autoload_namespaces.php
+++ b/vendor/composer/autoload_namespaces.php
@@ -8,4 +8,5 @@ $baseDir = dirname($vendorDir);
 return array(
     'Twig_' => array($vendorDir . '/twig/twig/lib'),
     'Pimple' => array($vendorDir . '/pimple/pimple/src'),
+    'Jsv4' => array($vendorDir . '/geraintluff/jsv4/src'),
 );

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -812,5 +812,57 @@
             }
         ],
         "description": "PHP MySQL Wrapper and object mapper which utilizes MySQLi and prepared statements"
+    },
+    {
+        "name": "geraintluff/jsv4",
+        "version": "dev-master",
+        "version_normalized": "9999999-dev",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/geraintluff/jsv4-php.git",
+            "reference": "b0fd384506e3b5c109777e6260523d4f76517537"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/geraintluff/jsv4-php/zipball/b0fd384506e3b5c109777e6260523d4f76517537",
+            "reference": "b0fd384506e3b5c109777e6260523d4f76517537",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.4.0"
+        },
+        "time": "2015-10-08 15:40:29",
+        "type": "library",
+        "installation-source": "source",
+        "autoload": {
+            "psr-0": {
+                "Jsv4": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Martin Bažík",
+                "email": "martin@bazo.sk",
+                "homepage": "http://bazo.sk"
+            },
+            {
+                "name": "Geraint Luff",
+                "email": "luffgd@gmail.com"
+            }
+        ],
+        "description": "A (coercive) JSON Schema v4 Validator for PHP",
+        "keywords": [
+            "Geraint Luff",
+            "JSON Schema",
+            "geraintluff",
+            "json",
+            "schema",
+            "v4",
+            "validator"
+        ]
     }
 ]


### PR DESCRIPTION
* Added jsv4-php as the backend validator (master branch must be used, the tagged 1.0.1 release has no namespaces support.)
* Enveloped all api paths into a group that has access the jsv4 class (routes.php).
* Written the first test schema (see Controllers/Api/v0_1/schemas/timepixels.json)
* Tested validity of GET public/api/0.1/timepixels/1 against the timepixels.json schema with the Online validator.
* Added a nice readme concerning the Json schema implementation (see Controllers/Api/README)
